### PR TITLE
5.1+ Fix (length_is deprecated and removed in Django 5.1)

### DIFF
--- a/django_admin_tailwind/templates/admin/includes/fieldset.html
+++ b/django_admin_tailwind/templates/admin/includes/fieldset.html
@@ -4,12 +4,12 @@
         <div class="description">{{ fieldset.description|safe }}</div>
     {% endif %}
     {% for line in fieldset %}
-        <div class="form-row{% if line.fields|length_is:'1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
-            {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
+        <div class="form-row{% if line.fields|length == '1' and line.errors %} errors{% endif %}{% if not line.has_visible_field %} hidden{% endif %}{% for field in line %}{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% endfor %}">
+            {% if line.fields|length == '1' %}{{ line.errors }}{% endif %}
             {% with field_klass="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5 flex justify-between items-center" %}
                 {% for field in line %}
-                    <div{% if not line.fields|length_is:'1' %} class="{{ field_klass }} fieldBox{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %}"{% elif field.is_checkbox %} class="{{ field_klass }} checkbox-row"{% else %} class="{{ field_klass }}"{% endif %}>
-                        {% if not line.fields|length_is:'1' and not field.is_readonly %}{{ field.errors }}{% endif %}
+                    <div{% if not line.fields|length == '1' %} class="{{ field_klass }} fieldBox{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% if not field.is_readonly and field.errors %} errors{% endif %}{% if field.field.is_hidden %} hidden{% endif %}"{% elif field.is_checkbox %} class="{{ field_klass }} checkbox-row"{% else %} class="{{ field_klass }}"{% endif %}>
+                        {% if not line.fields|length == '1' and not field.is_readonly %}{{ field.errors }}{% endif %}
                         {{ field.label_tag }}
                         {% if field.is_readonly %}
                             <div class="readonly">{{ field.contents }}</div>


### PR DESCRIPTION
Changed instances of "length_is" to "length" so that it is compatible with Django versions 5.1 and above